### PR TITLE
Allow for changing logging levels at runtime

### DIFF
--- a/internal/sensor/sensor.go
+++ b/internal/sensor/sensor.go
@@ -144,7 +144,9 @@ func (config *SensorConfig) ReadRoomAndWaterTemperature() (TemperatureReading, T
 }
 
 func (config *SensorConfig) IsLeakPresent() (bool, error) {
-	slog.Debug("IsLeakPresent")
+	slog.Debug(">>IsLeakPresent")
+	defer slog.Debug("<<IsLeakPresent")
+
 	if err := rpio.Open(); err != nil {
 		return false, err
 	}
@@ -214,7 +216,9 @@ func (device *DeviceConfig) IsOn() (bool, error) {
 }
 
 func (device *DeviceConfig) TurnOn() error {
-	slog.Debug("Device.TurnOn", "name", device.Name)
+	slog.Debug(">>Device.TurnOn", "name", device.Name)
+	defer slog.Debug("<<Device.TurnOn", "name", device.Name)
+
 	if err := rpio.Open(); err != nil {
 		return err
 	}
@@ -240,7 +244,9 @@ func (device *DeviceConfig) TurnOn() error {
 }
 
 func (device *DeviceConfig) TurnOff() error {
-	slog.Debug("Device.TurnOff", "name", device.Name)
+	slog.Debug(">>Device.TurnOff", "name", device.Name)
+	defer slog.Debug("<<Device.TurnOff", "name", device.Name)
+
 	if err := rpio.Open(); err != nil {
 		return err
 	}

--- a/services/health/health.go
+++ b/services/health/health.go
@@ -1,21 +1,35 @@
 package health
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
+	"os"
+	"strings"
 
 	"github.com/KyleBrandon/plunger-server/utils"
 )
 
-func NewHandler() *Handler {
-	return &Handler{}
+const DefaultLogLevel = slog.LevelInfo
+
+var current_level *slog.LevelVar
+
+func NewHandler(logger *slog.Logger) *Handler {
+	h := Handler{}
+	h.logger = logger
+	h.level = DefaultLogLevel
+	return &h
 }
 
-func (handler *Handler) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /v1/health", handler.handlerHealthGet)
+func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /v1/health", h.handlerHealthGet)
+	mux.HandleFunc("GET /v1/logger", h.handlerLoggerGet)
+	mux.HandleFunc("PUT /v1/logger", h.handlerLoggerUpdate)
 }
 
-func (handler *Handler) handlerHealthGet(writer http.ResponseWriter, req *http.Request) {
+func (h *Handler) handlerHealthGet(w http.ResponseWriter, r *http.Request) {
 	slog.Debug("enter handlerGetHealth")
 	response := struct {
 		Status string `json:"status"`
@@ -23,5 +37,86 @@ func (handler *Handler) handlerHealthGet(writer http.ResponseWriter, req *http.R
 		Status: "ok",
 	}
 
-	utils.RespondWithJSON(writer, http.StatusOK, response)
+	utils.RespondWithJSON(w, http.StatusOK, response)
+}
+
+func (h *Handler) handlerLoggerGet(w http.ResponseWriter, r *http.Request) {
+	slog.Debug(">>handlerLoggerGet")
+	defer slog.Debug("<<handlerLoggerGet")
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	slog.Info("Current log level", "level", h.level.String())
+
+	response := struct {
+		LogLevel string `json:"log_level"`
+	}{
+		LogLevel: fmt.Sprintf("Current log level: %s", h.level.String()),
+	}
+
+	utils.RespondWithJSON(w, http.StatusOK, response)
+}
+
+func (h *Handler) handlerLoggerUpdate(w http.ResponseWriter, r *http.Request) {
+	slog.Debug(">>handlerLoggerUpdate")
+	defer slog.Debug("<<handlerLoggerUpdate")
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		utils.RespondWithError(w, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+
+	defer r.Body.Close()
+
+	request := struct {
+		LogLevel string `json:"log_level"`
+	}{}
+
+	if err := json.Unmarshal(body, &request); err != nil {
+		utils.RespondWithError(w, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+
+	level, err := parseLogLevel(request.LogLevel)
+	if err != nil {
+		utils.RespondWithError(w, http.StatusBadRequest, "Invalid log level", err)
+		return
+	}
+
+	current_level.Set(level)
+
+	utils.RespondWithNoContent(w, http.StatusOK)
+}
+
+func parseLogLevel(logLevel string) (slog.Level, error) {
+	switch strings.ToLower(logLevel) {
+	case "debug":
+		return slog.LevelDebug, nil
+	case "info":
+		return slog.LevelInfo, nil
+	case "warn", "warning":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	case "fatal":
+		return slog.LevelError, nil // No fatal in slog, map to error.
+	default:
+		return slog.LevelInfo, fmt.Errorf("invalid log level: %s", logLevel)
+	}
+}
+
+func ConfigureLogger() *slog.Logger {
+	// TODO: don't like a global
+	current_level = new(slog.LevelVar)
+	current_level.Set(DefaultLogLevel)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr,
+		&slog.HandlerOptions{Level: current_level}))
+	slog.SetDefault(logger)
+
+	return logger
 }

--- a/services/health/types.go
+++ b/services/health/types.go
@@ -1,3 +1,12 @@
 package health
 
-type Handler struct{}
+import (
+	"log/slog"
+	"sync"
+)
+
+type Handler struct {
+	logger *slog.Logger
+	level  slog.Level
+	mu     sync.RWMutex
+}


### PR DESCRIPTION
Added GET and PUT for "/v1/logger" endpoint
GET returns the current log level
PUT allows you to change the current log level